### PR TITLE
Add Script to Download Pre-Built Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir -p /app \
   && chown -R nobody:nogroup /app
 WORKDIR /app
 
+# Source: https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#ubuntu--debian
 RUN apt-get update && apt-get install -y make gcc g++ autoconf autotools-dev bsdmainutils build-essential git libboost-all-dev \
   libcurl4-openssl-dev libdb++-dev libevent-dev libssl-dev libtool pkg-config python python-pip libzmq3-dev wget
 
@@ -68,7 +69,9 @@ RUN cd src \
 ## Build Final Image
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir -p /app \
   && chown -R nobody:nogroup /app \
@@ -77,10 +80,10 @@ RUN mkdir -p /app \
 
 WORKDIR /app
 
-# Copy binaries from build containers
-COPY --from=bitcoind-builder /app/* /app/
+# Copy binary from bitcoind-builder
+COPY --from=bitcoind-builder /app/bitcoind /app/bitcoind
 
-# Copy configuration files and set permissions
+# Copy binary from rosetta-builder
 COPY --from=rosetta-builder /app/* /app/
 
 # Set permissions for everything added to /app

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-local:
 build-release:
 	# make sure to always set version with vX.X.X
 	docker build -t rosetta-bitcoin:$(version) .;
-	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin.tar.gz;docker load --input rosetta-bitcoin.tar.gz;
+	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin-$(version).tar.gz;
 
 pull-remote:
 	curl -L https://github.com/coinbase/rosetta-bitcoin/releases/latest/download/rosetta-bitcoin.tar.gz -o rosetta-bitcoin.tar.gz;

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,8 @@ build-local:
 	docker build -t rosetta-bitcoin:latest .
 
 build-release:
-	# https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
 	docker build -t rosetta-bitcoin:$(version) .;
-	docker tag rosetta-bitcoin:$(version) docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:$(version);
-	docker push docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:$(version);
+	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin-$(version).tar.gz;
 
 run-mainnet-online:
 	docker run -d --ulimit "nofile=${NOFILE}:${NOFILE}" -v "${PWD}/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ build:
 build-local:
 	docker build -t rosetta-bitcoin:latest .
 
+build-release:
+	# https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
+	docker build -t rosetta-bitcoin:$(version) .;
+	docker tag rosetta-bitcoin:$(version) docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:$(version);
+	docker push docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:$(version);
+
 run-mainnet-online:
 	docker run -d --ulimit "nofile=${NOFILE}:${NOFILE}" -v "${PWD}/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,14 @@ build-local:
 	docker build -t rosetta-bitcoin:latest .
 
 build-release:
+	# make sure to always set version with vX.X.X
 	docker build -t rosetta-bitcoin:$(version) .;
-	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin-$(version).tar.gz;
+	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin.tar.gz;docker load --input rosetta-bitcoin.tar.gz;
+
+pull-remote:
+	curl -L https://github.com/coinbase/rosetta-bitcoin/releases/latest/download/rosetta-bitcoin.tar.gz -o rosetta-bitcoin.tar.gz;
+	docker load --input rosetta-bitcoin.tar.gz;
+	rm rosetta-bitcoin.tar.gz;
 
 run-mainnet-online:
 	docker run -d --ulimit "nofile=${NOFILE}:${NOFILE}" -v "${PWD}/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,6 @@ build-release:
 	docker build -t rosetta-bitcoin:$(version) .;
 	docker save rosetta-bitcoin:$(version) | gzip > rosetta-bitcoin-$(version).tar.gz;
 
-pull-remote:
-	curl -L https://github.com/coinbase/rosetta-bitcoin/releases/latest/download/rosetta-bitcoin.tar.gz -o rosetta-bitcoin.tar.gz;
-	docker load --input rosetta-bitcoin.tar.gz;
-	rm rosetta-bitcoin.tar.gz;
-
 run-mainnet-online:
 	docker run -d --ulimit "nofile=${NOFILE}:${NOFILE}" -v "${PWD}/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ all Rosetta implementations must be deployable via Docker and support running vi
 ### Install
 #### Pre-Built
 You can download a pre-built Docker image from GitHub:
+TODO: Change to docker import from a release
 ```text
 docker pull docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:v0.0.1
 ```
@@ -52,7 +53,7 @@ and start the `rosetta-bitcoin` server at port `8080`.
 
 #### Mainnet:Online
 ```text
-docker run -d --ulimit "nofile=100000:100000" -v "$(shell pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:v0.0.1
+docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:v0.0.1
 ```
 
 #### Mainnet:Offline
@@ -62,7 +63,7 @@ docker run -d -e "MODE=OFFLINE" -e "NETWORK=MAINNET" -e "PORT=8081" -p 8081:8081
 
 #### Testnet:Online
 ```text
-docker run -d --ulimit "nofile=100000:100000" -v "$(shell pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:v0.0.1
+docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:v0.0.1
 ```
 
 #### Testnet:Offline

--- a/README.md
+++ b/README.md
@@ -34,47 +34,54 @@ As specified in the [Rosetta API Principles](https://www.rosetta-api.org/docs/au
 all Rosetta implementations must be deployable via Docker and support running via either an
 [`online` or `offline` mode](https://www.rosetta-api.org/docs/node_deployment.html#multiple-modes).
 
+**YOU MUST INSTALL DOCKER FOR THE FOLLOWING INSTRUCTIONS TO WORK. YOU CAN DOWNLOAD
+DOCKER [HERE](https://www.docker.com/get-started).**
+
 ### Install
-#### Pre-Built
-You can download a pre-built Docker image from GitHub:
-TODO: cast version as latest somehow?
-TODO: get latest from release info and then can do automatically? Could do another script...
+Running the following commands will create a Docker image called `rosetta-bitcoin:latest`.
+
+#### From GitHub
+To download the pre-built Docker image from the latest release, run:
 ```text
-curl -L https://github.com/coinbase/rosetta-bitcoin/releases/latest/download/rosetta-bitcoin.tar.gz -o rosetta-bitcoin.tar.gz;
-docker load --input rosetta-bitcoin.tar.gz;
-rm rosetta-bitcoin.tar.gz;
+curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-bitcoin/master/install.sh | sh -s
 ```
-_This will print the image tag out that must be used for running in later steps._
+_Do not try to install rosetta-bitcoin using GitHub Packages!_
 
 #### From Source
-You can clone this repository and run the following command:
+After cloning this repository, run:
 ```text
-docker build -t rosetta-bitcoin:latest
+make build-local
 ```
 
 ### Run
-By default, running these commands will create a data directory at `<working directory>/bitcoin-data`
-and start the `rosetta-bitcoin` server at port `8080`.
+Running the following commands will start a Docker container in
+[detached mode](https://docs.docker.com/engine/reference/run/#detached--d) with
+a data directory at `<working directory>/bitcoin-data` and the Rosetta API accessible
+at port `8080`.
 
 #### Mainnet:Online
 ```text
 docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest
 ```
+_If you cloned the repository, you can run `make run-mainnet-online`._
 
 #### Mainnet:Offline
 ```text
 docker run -d -e "MODE=OFFLINE" -e "NETWORK=MAINNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:latest
 ```
+_If you cloned the repository, you can run `make run-mainnet-offline`._
 
 #### Testnet:Online
 ```text
 docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:latest
 ```
+_If you cloned the repository, you can run `make run-testnet-online`._
 
 #### Testnet:Offline
 ```text
 docker run -d -e "MODE=OFFLINE" -e "NETWORK=TESTNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:latest
 ```
+_If you cloned the repository, you can run `make run-testnet-offline`._
 
 ## System Requirements
 `rosetta-bitcoin` has been tested on an [AWS c5.2xlarge instance](https://aws.amazon.com/ec2/instance-types/c5).

--- a/README.md
+++ b/README.md
@@ -34,15 +34,41 @@ As specified in the [Rosetta API Principles](https://www.rosetta-api.org/docs/au
 all Rosetta implementations must be deployable via Docker and support running via either an
 [`online` or `offline` mode](https://www.rosetta-api.org/docs/node_deployment.html#multiple-modes).
 
-To build a Docker image from this repository, run the command `make build`. To start
-`rosetta-bitcoin`, you can run:
-* `make run-mainnet-online`
-* `make run-mainnet-offline`
-* `make run-testnet-online`
-* `make run testnet-offline`
+### Install
+#### Pre-Built
+You can download a pre-built Docker image from GitHub:
+```text
+docker pull docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:v0.0.1
+```
+#### From Source
+You can clone this repository and run the following command:
+```text
+docker build -t rosetta-bitcoin:v0.0.1
+```
 
+### Run
 By default, running these commands will create a data directory at `<working directory>/bitcoin-data`
 and start the `rosetta-bitcoin` server at port `8080`.
+
+#### Mainnet:Online
+```text
+docker run -d --ulimit "nofile=100000:100000" -v "$(shell pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:v0.0.1
+```
+
+#### Mainnet:Offline
+```text
+docker run -d -e "MODE=OFFLINE" -e "NETWORK=MAINNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:v0.0.1
+```
+
+#### Testnet:Online
+```text
+docker run -d --ulimit "nofile=100000:100000" -v "$(shell pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:v0.0.1
+```
+
+#### Testnet:Offline
+```text
+docker run -d -e "MODE=OFFLINE" -e "NETWORK=TESTNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:v0.0.1
+```
 
 ## System Requirements
 `rosetta-bitcoin` has been tested on an [AWS c5.2xlarge instance](https://aws.amazon.com/ec2/instance-types/c5).

--- a/README.md
+++ b/README.md
@@ -37,14 +37,19 @@ all Rosetta implementations must be deployable via Docker and support running vi
 ### Install
 #### Pre-Built
 You can download a pre-built Docker image from GitHub:
-TODO: Change to docker import from a release
+TODO: cast version as latest somehow?
+TODO: get latest from release info and then can do automatically? Could do another script...
 ```text
-docker pull docker.pkg.github.com/coinbase/rosetta-bitcoin/rosetta-bitcoin:v0.0.1
+curl -L https://github.com/coinbase/rosetta-bitcoin/releases/latest/download/rosetta-bitcoin.tar.gz -o rosetta-bitcoin.tar.gz;
+docker load --input rosetta-bitcoin.tar.gz;
+rm rosetta-bitcoin.tar.gz;
 ```
+_This will print the image tag out that must be used for running in later steps._
+
 #### From Source
 You can clone this repository and run the following command:
 ```text
-docker build -t rosetta-bitcoin:v0.0.1
+docker build -t rosetta-bitcoin:latest
 ```
 
 ### Run
@@ -53,22 +58,22 @@ and start the `rosetta-bitcoin` server at port `8080`.
 
 #### Mainnet:Online
 ```text
-docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:v0.0.1
+docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=MAINNET" -e "PORT=8080" -p 8080:8080 -p 8333:8333 rosetta-bitcoin:latest
 ```
 
 #### Mainnet:Offline
 ```text
-docker run -d -e "MODE=OFFLINE" -e "NETWORK=MAINNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:v0.0.1
+docker run -d -e "MODE=OFFLINE" -e "NETWORK=MAINNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:latest
 ```
 
 #### Testnet:Online
 ```text
-docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:v0.0.1
+docker run -d --ulimit "nofile=100000:100000" -v "$(pwd)/bitcoin-data:/data" -e "MODE=ONLINE" -e "NETWORK=TESTNET" -e "PORT=8080" -p 8080:8080 -p 18333:18333 rosetta-bitcoin:latest
 ```
 
 #### Testnet:Offline
 ```text
-docker run -d -e "MODE=OFFLINE" -e "NETWORK=TESTNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:v0.0.1
+docker run -d -e "MODE=OFFLINE" -e "NETWORK=TESTNET" -e "PORT=8081" -p 8081:8081 rosetta-bitcoin:latest
 ```
 
 ## System Requirements

--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,9 @@ execute() {
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}" "" "1"
   docker load --input "${tmpdir}/${TARBALL}"
   docker tag "rosetta-bitcoin:${TAG}" "rosetta-bitcoin:latest"
-  log_info "installed rosetta-bitcoin:${TAG} and tagged as rosetta-bitcoin:latest"
+  log_info "loaded rosetta-bitcoin:${TAG} and tagged as rosetta-bitcoin:latest"
   rm -rf "${tmpdir}"
+  log_info "removed temporary directory ${tmpdir}"
 }
 github_tag() {
   log_info "checking GitHub for latest tag"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Inspired by: https://github.com/golangci/golangci-lint/blob/master/install.sh
+
+usage() {
+  this=$1
+  cat <<EOF
+$this: download pre-compiled Docker images for coinbase/rosetta-bitcoin 
+
+Usage: $this [-d]
+  -d turns on debug logging
+
+EOF
+  exit 2
+}
+
+parse_args() {
+  while getopts "dh?" arg; do
+    case "$arg" in
+      d) log_set_priority 10 ;;
+      h | \?) usage "$0" ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  TAG=$1
+}
+execute() {
+  tmpdir=$(mktemp -d)
+  log_debug "downloading image into ${tmpdir}"
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  docker load --input "${tmpdir}/${TARBALL}"
+  docker tag "rosetta-bitcoin:${TAG}" "rosetta-bitcoin:latest"
+  log_info "installed rosetta-bitcoin:${TAG} and tagged as rosetta-bitcoin:latest"
+  rm -rf "${tmpdir}"
+}
+github_tag() {
+  log_info "checking GitHub for latest tag"
+  REALTAG=$(github_release "$OWNER/$REPO" "${TAG}")
+  TAG="$REALTAG"
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+is_command() {
+  command -v "$1" >/dev/null
+}
+echoerr() {
+  echo "$@" 1>&2
+}
+log_prefix() {
+  echo "$0"
+}
+_logp=6
+log_set_priority() {
+  _logp="$1"
+}
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+log_debug() {
+  log_priority 7 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+log_info() {
+  log_priority 6 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+log_crit() {
+  log_priority 2 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+}
+uname_os() {
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+untar() {
+  tarball=$1
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+}
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+github_release() {
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+End of functions from https://github.com/client9/shlib
+------------------------------------------------------------------------
+EOF
+
+BINARY=rosetta-bitcoin
+FORMAT=tar.gz
+OWNER=coinbase
+REPO="rosetta-bitcoin"
+PREFIX="$OWNER/$REPO"
+
+# use in logging routines
+log_prefix() {
+	echo "$PREFIX"
+}
+GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+
+parse_args "$@"
+
+github_tag
+
+log_info "found version: ${TAG}"
+
+NAME=${BINARY}-${TAG}
+TARBALL=${NAME}.${FORMAT}
+TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+
+execute


### PR DESCRIPTION
This PR adds a script that downloads the latest pre-built tar from GitHub releases.

```text
coinbase/rosetta-bitcoin info checking GitHub for latest tag
coinbase/rosetta-bitcoin info found version: v0.0.2
coinbase/rosetta-bitcoin info downloading image into /var/folders/s_/4_zs0b1j1kz3hb5_jmdfxb4m0000gn/T/tmp.dqSg1NZN
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   655  100   655    0     0   1452      0 --:--:-- --:--:-- --:--:--  1452
100  135M  100  135M    0     0  1635k      0  0:01:25  0:01:25 --:--:-- 1667k
59322dba5499: Loading layer [==================================================>]  21.85MB/21.85MB
6d772440b89f: Loading layer [==================================================>]  123.7MB/123.7MB
Loaded image: rosetta-bitcoin:v0.0.2
coinbase/rosetta-bitcoin info loaded rosetta-bitcoin:v0.0.2 and tagged as rosetta-bitcoin:latest
coinbase/rosetta-bitcoin info removed temporary directory /var/folders/s_/4_zs0b1j1kz3hb5_jmdfxb4m0000gn/T/tmp.dqSg1NZN
```

### Changes
- [x] Update `README` with new instructions to download pre-built image
- [x] Add script to download pre-built image
- [x] add `Makefile` command to create a new tar to upload to GitHub