### PR TITLE
[services] Fix NetworkStatus.CurrentBlockTimestamp

### DIFF
--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -161,32 +161,6 @@ func newHTTPClient(timeout time.Duration) *http.Client {
 	return httpClient
 }
 
-// NetworkStatus returns the *types.NetworkStatusResponse for
-// bitcoind.
-func (b *Client) NetworkStatus(ctx context.Context) (*types.NetworkStatusResponse, error) {
-	rawBlock, err := b.getBlock(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("%w: unable to get current block", err)
-	}
-
-	currentBlock, err := b.parseBlockData(rawBlock)
-	if err != nil {
-		return nil, fmt.Errorf("%w: unable to parse current block", err)
-	}
-
-	peers, err := b.GetPeers(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &types.NetworkStatusResponse{
-		CurrentBlockIdentifier: currentBlock.BlockIdentifier,
-		CurrentBlockTimestamp:  currentBlock.Timestamp,
-		GenesisBlockIdentifier: b.genesisBlockIdentifier,
-		Peers:                  peers,
-	}, nil
-}
-
 // GetPeers fetches the list of peer nodes
 func (b *Client) GetPeers(ctx context.Context) ([]*types.Peer, error) {
 	info, err := b.getPeerInfo(ctx)

--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -161,6 +161,32 @@ func newHTTPClient(timeout time.Duration) *http.Client {
 	return httpClient
 }
 
+// NetworkStatus returns the *types.NetworkStatusResponse for
+// bitcoind.
+func (b *Client) NetworkStatus(ctx context.Context) (*types.NetworkStatusResponse, error) {
+	rawBlock, err := b.getBlock(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to get current block", err)
+	}
+
+	currentBlock, err := b.parseBlockData(rawBlock)
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to parse current block", err)
+	}
+
+	peers, err := b.GetPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.NetworkStatusResponse{
+		CurrentBlockIdentifier: currentBlock.BlockIdentifier,
+		CurrentBlockTimestamp:  currentBlock.Timestamp,
+		GenesisBlockIdentifier: b.genesisBlockIdentifier,
+		Peers:                  peers,
+	}, nil
+}
+
 // GetPeers fetches the list of peer nodes
 func (b *Client) GetPeers(ctx context.Context) ([]*types.Peer, error) {
 	info, err := b.getPeerInfo(ctx)

--- a/bitcoin/client_test.go
+++ b/bitcoin/client_test.go
@@ -293,66 +293,51 @@ var (
 	}
 )
 
-func TestNetworkStatus(t *testing.T) {
+func TestGetPeers(t *testing.T) {
 	tests := map[string]struct {
 		responses []responseFixture
 
-		expectedStatus *types.NetworkStatusResponse
-		expectedError  error
+		expectedPeers []*types.Peer
+		expectedError error
 	}{
 		"successful": {
 			responses: []responseFixture{
-				{
-					status: http.StatusOK,
-					body:   loadFixture("get_blockchain_info_response.json"),
-					url:    url,
-				},
-				{
-					status: http.StatusOK,
-					body:   loadFixture("get_block_response.json"),
-					url:    url,
-				},
 				{
 					status: http.StatusOK,
 					body:   loadFixture("get_peer_info_response.json"),
 					url:    url,
 				},
 			},
-			expectedStatus: &types.NetworkStatusResponse{
-				CurrentBlockIdentifier: blockIdentifier1000,
-				CurrentBlockTimestamp:  block1000.Time * 1000,
-				GenesisBlockIdentifier: MainnetGenesisBlockIdentifier,
-				Peers: []*types.Peer{
-					{
-						PeerID: "77.93.223.9:8333",
-						Metadata: forceMarshalMap(t, &PeerInfo{
-							Addr:           "77.93.223.9:8333",
-							Version:        70015,
-							SubVer:         "/Satoshi:0.14.2/",
-							StartingHeight: 643579,
-							RelayTxes:      true,
-							LastSend:       1597606676,
-							LastRecv:       1597606677,
-							BanScore:       0,
-							SyncedHeaders:  644046,
-							SyncedBlocks:   644046,
-						}),
-					},
-					{
-						PeerID: "172.105.93.179:8333",
-						Metadata: forceMarshalMap(t, &PeerInfo{
-							Addr:           "172.105.93.179:8333",
-							RelayTxes:      true,
-							LastSend:       1597606678,
-							LastRecv:       1597606676,
-							Version:        70015,
-							SubVer:         "/Satoshi:0.18.1/",
-							StartingHeight: 643579,
-							BanScore:       0,
-							SyncedHeaders:  644046,
-							SyncedBlocks:   644046,
-						}),
-					},
+			expectedPeers: []*types.Peer{
+				{
+					PeerID: "77.93.223.9:8333",
+					Metadata: forceMarshalMap(t, &PeerInfo{
+						Addr:           "77.93.223.9:8333",
+						Version:        70015,
+						SubVer:         "/Satoshi:0.14.2/",
+						StartingHeight: 643579,
+						RelayTxes:      true,
+						LastSend:       1597606676,
+						LastRecv:       1597606677,
+						BanScore:       0,
+						SyncedHeaders:  644046,
+						SyncedBlocks:   644046,
+					}),
+				},
+				{
+					PeerID: "172.105.93.179:8333",
+					Metadata: forceMarshalMap(t, &PeerInfo{
+						Addr:           "172.105.93.179:8333",
+						RelayTxes:      true,
+						LastSend:       1597606678,
+						LastRecv:       1597606676,
+						Version:        70015,
+						SubVer:         "/Satoshi:0.18.1/",
+						StartingHeight: 643579,
+						BanScore:       0,
+						SyncedHeaders:  644046,
+						SyncedBlocks:   644046,
+					}),
 				},
 			},
 		},
@@ -366,28 +351,8 @@ func TestNetworkStatus(t *testing.T) {
 			},
 			expectedError: errors.New("rpc in warmup"),
 		},
-		"blockchain info error": {
+		"peer info error": {
 			responses: []responseFixture{
-				{
-					status: http.StatusInternalServerError,
-					body:   "{}",
-					url:    url,
-				},
-			},
-			expectedError: errors.New("invalid response: 500 Internal Server Error"),
-		},
-		"peer info not accessible": {
-			responses: []responseFixture{
-				{
-					status: http.StatusOK,
-					body:   loadFixture("get_blockchain_info_response.json"),
-					url:    url,
-				},
-				{
-					status: http.StatusOK,
-					body:   loadFixture("get_block_response.json"),
-					url:    url,
-				},
 				{
 					status: http.StatusInternalServerError,
 					body:   "{}",
@@ -420,12 +385,12 @@ func TestNetworkStatus(t *testing.T) {
 			}))
 
 			client := NewClient(ts.URL, MainnetGenesisBlockIdentifier, MainnetCurrency)
-			status, err := client.NetworkStatus(context.Background())
+			peers, err := client.GetPeers(context.Background())
 			if test.expectedError != nil {
 				assert.Contains(err.Error(), test.expectedError.Error())
 			} else {
 				assert.NoError(err)
-				assert.Equal(test.expectedStatus, status)
+				assert.Equal(test.expectedPeers, peers)
 			}
 		})
 	}

--- a/mocks/services/client.go
+++ b/mocks/services/client.go
@@ -15,16 +15,16 @@ type Client struct {
 	mock.Mock
 }
 
-// NetworkStatus provides a mock function with given fields: _a0
-func (_m *Client) NetworkStatus(_a0 context.Context) (*types.NetworkStatusResponse, error) {
+// GetPeers provides a mock function with given fields: _a0
+func (_m *Client) GetPeers(_a0 context.Context) ([]*types.Peer, error) {
 	ret := _m.Called(_a0)
 
-	var r0 *types.NetworkStatusResponse
-	if rf, ok := ret.Get(0).(func(context.Context) *types.NetworkStatusResponse); ok {
+	var r0 []*types.Peer
+	if rf, ok := ret.Get(0).(func(context.Context) []*types.Peer); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.NetworkStatusResponse)
+			r0 = ret.Get(0).([]*types.Peer)
 		}
 	}
 

--- a/services/network_service.go
+++ b/services/network_service.go
@@ -65,7 +65,7 @@ func (s *NetworkAPIService) NetworkStatus(
 		return nil, wrapErr(ErrUnavailableOffline, nil)
 	}
 
-	rawStatus, err := s.client.NetworkStatus(ctx)
+	peers, err := s.client.GetPeers(ctx)
 	if err != nil {
 		return nil, wrapErr(ErrBitcoind, err)
 	}
@@ -75,9 +75,12 @@ func (s *NetworkAPIService) NetworkStatus(
 		return nil, wrapErr(ErrNotReady, nil)
 	}
 
-	rawStatus.CurrentBlockIdentifier = cachedBlockResponse.Block.BlockIdentifier
-
-	return rawStatus, nil
+	return &types.NetworkStatusResponse{
+		CurrentBlockIdentifier: cachedBlockResponse.Block.BlockIdentifier,
+		CurrentBlockTimestamp:  cachedBlockResponse.Block.Timestamp,
+		GenesisBlockIdentifier: s.config.GenesisBlockIdentifier,
+		Peers:                  peers,
+	}, nil
 }
 
 // NetworkOptions implements the /network/options endpoint.

--- a/services/types.go
+++ b/services/types.go
@@ -44,7 +44,7 @@ var (
 // Client is used by the servicers to get Peer information
 // and to submit transactions.
 type Client interface {
-	NetworkStatus(context.Context) (*types.NetworkStatusResponse, error)
+	GetPeers(context.Context) ([]*types.Peer, error)
 	SendRawTransaction(context.Context, string) (string, error)
 	SuggestedFeeRate(context.Context, int64) (float64, error)
 	RawMempool(context.Context) ([]string, error)

--- a/services/types.go
+++ b/services/types.go
@@ -38,7 +38,7 @@ var (
 	// variable instead of a constant because
 	// we typically need the pointer of this
 	// value.
-	MiddlewareVersion = "0.0.2"
+	MiddlewareVersion = "0.0.3"
 )
 
 // Client is used by the servicers to get Peer information


### PR DESCRIPTION
The `/network/status` response contained the `CurrentBlockTimestamp` of the last synced block by `bitcoind` instead of the `indexer`. This meant we were returning a timestamp that wasn't associated with the last queryable block (this can cause some "at tip" status checks to erroneously return true).

### Changes
- [x] return current block timestamp from last block indexed
- [x] update middleware version to `0.0.3`