### PR TITLE
Update version

### DIFF
--- a/services/network_service_test.go
+++ b/services/network_service_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	middlewareVersion     = "0.0.5"
+	middlewareVersion     = "0.0.6"
 	defaultNetworkOptions = &types.NetworkOptionsResponse{
 		Version: &types.Version{
 			RosettaVersion:    types.RosettaAPIVersion,

--- a/services/types.go
+++ b/services/types.go
@@ -42,7 +42,7 @@ var (
 	// variable instead of a constant because
 	// we typically need the pointer of this
 	// value.
-	MiddlewareVersion = "0.0.5"
+	MiddlewareVersion = "0.0.6"
 )
 
 // Client is used by the servicers to get Peer information


### PR DESCRIPTION
This PR updates the `rosetta-bitcoin` version to `0.0.6`.