### PR TITLE
'make lint' fix - update.go fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       name: default
     steps:
       - *fast-checkout
-      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.32.2
       - run: make lint
   check-license:
     executor:

--- a/bitcoin/node.go
+++ b/bitcoin/node.go
@@ -43,7 +43,7 @@ func logPipe(ctx context.Context, pipe io.ReadCloser, identifier string) error {
 			return err
 		}
 
-		message := strings.Replace(str, "\n", "", -1)
+		message := strings.ReplaceAll(str, "\n", "")
 		messages := strings.SplitAfterN(message, " ", 2)
 
 		// Trim the timestamp from the log if it exists


### PR DESCRIPTION
functional replacement for https://golang.org/pkg/strings/#Replace

to https://golang.org/pkg/strings/#ReplaceAll

since 1.31 golangci-lint gocritic was updated to include replace to replaceall hint.

ReplaceAll was added in Go 1.12

See https://github.com/go-critic/go-critic/issues/872 for more.


### Motivation
closes #40 

### Solution
Replace to ReplaceAll swap (remove last param of -1 meaning to replace all matches)

### Open questions
Go 1.12 will be minimum version, is this OK?
