### PR TITLE
[doc] add comment to clarify use of ENV variable

### DIFF
--- a/rosetta-cli-conf/testnet/bitcoin.ros
+++ b/rosetta-cli-conf/testnet/bitcoin.ros
@@ -188,6 +188,13 @@ return_funds(10){
     });
 
     // We load the recipient address from an ENV.
+    // The reason we read from ENV variable is that the recipient address here
+    // is the sender's address from transfer workflow which is not accessible
+    // by this workflow.
+    // When setting the ENV variable make sure to set it so that it has double
+    // quotes around, otherwise it will give a parsing issue
+    // Set it using export RECIPIENT=\"<sender's address>\"
+    // Eventually we would want it to be automatically set by transfer workflow
     recipient_address = load_env("RECIPIENT");
     recipient = {"address": {{recipient_address}}};
 


### PR DESCRIPTION
Fixes # .

### Motivation
In the bitcoin.ros file, it was not clear what to set RECIPIENT to and why we are loading it from ENV

### Solution
This comment just explains the above

TODO: We also want this to be automated so that we don't have to manually set it. This will require some effort to introduce a set_env `Action` and will be done in subsequent PR.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
