### PR TITLE
enable parsing output address in field of string type

### DIFF
--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -773,11 +773,13 @@ func (b *Client) parseAmount(amount float64) (uint64, error) {
 func (b *Client) parseOutputAccount(
 	scriptPubKey *ScriptPubKey,
 ) *types.AccountIdentifier {
-	if len(scriptPubKey.Addresses) != 1 {
-		return &types.AccountIdentifier{Address: scriptPubKey.Hex}
+	if scriptPubKey.Address == "" {
+		if len(scriptPubKey.Addresses) != 1 {
+			return &types.AccountIdentifier{Address: scriptPubKey.Hex}
+		}
+		return &types.AccountIdentifier{Address: scriptPubKey.Addresses[0]}
 	}
-
-	return &types.AccountIdentifier{Address: scriptPubKey.Addresses[0]}
+	return &types.AccountIdentifier{Address: scriptPubKey.Address}
 }
 
 // coinbaseTxOperation constructs a transaction operation for the coinbase input.

--- a/bitcoin/client_fixtures/get_block_response_2_bis.json
+++ b/bitcoin/client_fixtures/get_block_response_2_bis.json
@@ -1,0 +1,168 @@
+{
+  "result": {
+    "hash": "000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506",
+    "confirmations": 544053,
+    "strippedsize": 957,
+    "size": 957,
+    "weight": 3828,
+    "height": 100000,
+    "version": 1,
+    "versionHex": "00000001",
+    "merkleroot": "f3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766",
+    "tx": [
+      {
+        "txid": "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87",
+        "hash": "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87",
+        "version": 1,
+        "size": 135,
+        "vsize": 135,
+        "weight": 540,
+        "locktime": 0,
+        "vin": [
+          {
+            "coinbase": "044c86041b020602",
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 15.89351625,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "OP_HASH160 228f554bbf766d6f9cc828de1126e3d35d15e5fe OP_EQUAL",
+              "hex": "a914228f554bbf766d6f9cc828de1126e3d35d15e5fe87",
+              "reqSigs": 1,
+              "type": "scripthash",
+              "address": "34qkc2iac6RsyxZVfyE2S5U5WcRsbg2dpK"
+            }
+          },
+          {
+            "value": 0,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "OP_RETURN aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+              "hex": "6a24aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+              "type": "nulldata"
+            }
+          }
+        ],
+        "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84ac00000000"
+      },
+      {
+        "txid": "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+        "hash": "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+        "version": 1,
+        "size": 259,
+        "vsize": 259,
+        "weight": 1036,
+        "locktime": 0,
+        "vin": [
+          {
+            "txid": "87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3",
+              "hex": "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3"
+            },
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 5.56,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+              "hex": "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+              "reqSigs": 1,
+              "type": "pubkeyhash",
+              "address": "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn"
+            }
+          },
+          {
+            "value": 44.44,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "OP_DUP OP_HASH160 948c765a6914d43f2a7ac177da2c2f6b52de3d7c OP_EQUALVERIFY OP_CHECKSIG",
+              "hex": "76a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac",
+              "reqSigs": 1,
+              "type": "pubkeyhash",
+              "address": "1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx"
+            }
+          }
+        ],
+        "hex": "0100000001032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a187000000008c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff0200e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00000000"
+      },
+      {
+        "txid": "fake",
+        "hash": "fake",
+        "version": 2,
+        "size": 421,
+        "vsize": 612,
+        "weight": 129992,
+        "locktime": 10,
+        "vin": [
+          {
+            "txid": "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+              "hex": "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78"
+            },
+            "txinwitness": [
+              "304402205f39ccbab38b644acea0776d18cb63ce3e37428cbac06dc23b59c61607aef69102206b8610827e9cb853ea0ba38983662034bd3575cc1ab118fb66d6a98066fa0bed01",
+              "0304c01563d46e38264283b99bb352b46e69bf132431f102d4bd9a9d8dab075e7f"
+            ],
+            "sequence": 4294967295
+          },
+          {
+            "txid": "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5",
+            "vout": 1,
+            "scriptSig": {
+              "asm": "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+              "hex": "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78"
+            },
+            "sequence": 4294967295
+          },
+          {
+            "txid": "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3",
+              "hex": "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3"
+            },
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 200.56,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+              "hex": "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+              "reqSigs": 1,
+              "type": "pubkeyhash",
+              "addresses": [
+                "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+                "1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx"
+              ]
+            }
+          }
+        ],
+        "hex": "fake hex"
+      }
+    ],
+    "time": 1293623863,
+    "mediantime": 1293622620,
+    "nonce": 274148111,
+    "bits": "1b04864c",
+    "difficulty": 14484.1623612254,
+    "chainwork": "0000000000000000000000000000000000000000000000000644cb7f5234089e",
+    "nTx": 4,
+    "previousblockhash": "000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250",
+    "nextblockhash": "00000000000080b66c911bd5ba14a74260057311eaeb1982802f7010f1a9f090"
+  },
+  "error": null,
+  "id": "curltest"
+}

--- a/bitcoin/client_test.go
+++ b/bitcoin/client_test.go
@@ -290,6 +290,167 @@ var (
 			},
 		},
 	}
+
+	blockIdentifier100000_bis = &types.BlockIdentifier{
+		Hash:  "000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506",
+		Index: 100000,
+	}
+
+	block100000_bis = &Block{
+		Hash:              "000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506",
+		Height:            100000,
+		PreviousBlockHash: "000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250",
+		Time:              1293623863,
+		Size:              957,
+		Weight:            3828,
+		Version:           1,
+		MerkleRoot:        "f3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766",
+		MedianTime:        1293622620,
+		Nonce:             274148111,
+		Bits:              "1b04864c",
+		Difficulty:        14484.1623612254,
+		Txs: []*Transaction{
+			{
+				Hex:      "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84ac00000000", // nolint
+				Hash:     "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87",
+				Size:     135,
+				Vsize:    135,
+				Version:  1,
+				Locktime: 0,
+				Weight:   540,
+				Inputs: []*Input{
+					{
+						Coinbase: "044c86041b020602",
+						Sequence: 4294967295,
+					},
+				},
+				Outputs: []*Output{
+					{
+						Value: 15.89351625,
+						Index: 0,
+						ScriptPubKey: &ScriptPubKey{
+							ASM:          "OP_HASH160 228f554bbf766d6f9cc828de1126e3d35d15e5fe OP_EQUAL",
+							Hex:          "a914228f554bbf766d6f9cc828de1126e3d35d15e5fe87",
+							RequiredSigs: 1,
+							Type:         "scripthash",
+							Address:      "34qkc2iac6RsyxZVfyE2S5U5WcRsbg2dpK",
+						},
+					},
+					{
+						Value: 0,
+						Index: 1,
+						ScriptPubKey: &ScriptPubKey{
+							ASM:  "OP_RETURN aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+							Hex:  "6a24aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+							Type: "nulldata",
+						},
+					},
+				},
+			},
+			{
+				Hex:      "0100000001032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a187000000008c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff0200e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00000000", // nolint
+				Hash:     "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+				Size:     259,
+				Vsize:    259,
+				Version:  1,
+				Locktime: 0,
+				Weight:   1036,
+				Inputs: []*Input{
+					{
+						TxHash: "87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03",
+						Vout:   0,
+						ScriptSig: &ScriptSig{
+							ASM: "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+							Hex: "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+						},
+						Sequence: 4294967295,
+					},
+				},
+				Outputs: []*Output{
+					{
+						Value: 5.56,
+						Index: 0,
+						ScriptPubKey: &ScriptPubKey{
+							ASM:          "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+							Hex:          "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+							RequiredSigs: 1,
+							Type:         "pubkeyhash",
+							Address:      "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+						},
+					},
+					{
+						Value: 44.44,
+						Index: 1,
+						ScriptPubKey: &ScriptPubKey{
+							ASM:          "OP_DUP OP_HASH160 948c765a6914d43f2a7ac177da2c2f6b52de3d7c OP_EQUALVERIFY OP_CHECKSIG",
+							Hex:          "76a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac",
+							RequiredSigs: 1,
+							Type:         "pubkeyhash",
+							Address:      "1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
+						},
+					},
+				},
+			},
+			{
+				Hash:     "fake",
+				Hex:      "fake hex",
+				Version:  2,
+				Size:     421,
+				Vsize:    612,
+				Weight:   129992,
+				Locktime: 10,
+				Inputs: []*Input{
+					{
+						TxHash: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5",
+						Vout:   0,
+						ScriptSig: &ScriptSig{
+							ASM: "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+							Hex: "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+						},
+						TxInWitness: []string{
+							"304402205f39ccbab38b644acea0776d18cb63ce3e37428cbac06dc23b59c61607aef69102206b8610827e9cb853ea0ba38983662034bd3575cc1ab118fb66d6a98066fa0bed01", // nolint
+							"0304c01563d46e38264283b99bb352b46e69bf132431f102d4bd9a9d8dab075e7f",
+						},
+						Sequence: 4294967295,
+					},
+					{
+						TxHash: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5",
+						Vout:   1,
+						ScriptSig: &ScriptSig{
+							ASM: "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+							Hex: "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+						},
+						Sequence: 4294967295,
+					},
+					{
+						TxHash: "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+						Vout:   0,
+						ScriptSig: &ScriptSig{
+							ASM: "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+							Hex: "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+						},
+						Sequence: 4294967295,
+					},
+				},
+				Outputs: []*Output{
+					{
+						Value: 200.56,
+						Index: 0,
+						ScriptPubKey: &ScriptPubKey{
+							ASM:          "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+							Hex:          "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+							RequiredSigs: 1,
+							Type:         "pubkeyhash",
+							Addresses: []string{
+								"1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+								"1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestNetworkStatus(t *testing.T) {
@@ -568,6 +729,24 @@ func TestGetRawBlock(t *testing.T) {
 				},
 			},
 			expectedBlock: block100000,
+			expectedCoins: []string{
+				"87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03:0",
+				"503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:0",
+				"503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:1",
+			},
+		},
+		"lookup by hash 2 (bis)": {
+			blockIdentifier: &types.PartialBlockIdentifier{
+				Hash: &blockIdentifier100000_bis.Hash,
+			},
+			responses: []responseFixture{
+				{
+					status: http.StatusOK,
+					body:   loadFixture("get_block_response_2_bis.json"),
+					url:    url,
+				},
+			},
+			expectedBlock: block100000_bis,
 			expectedCoins: []string{
 				"87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03:0",
 				"503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:0",
@@ -1089,6 +1268,386 @@ func TestParseBlock(t *testing.T) {
 										Addresses: []string{
 											"1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
 										},
+									},
+								}),
+							},
+						},
+						Metadata: mustMarshalMap(&TransactionMetadata{
+							Size:    259,
+							Version: 1,
+							Vsize:   259,
+							Weight:  1036,
+						}),
+					},
+					{
+						TransactionIdentifier: &types.TransactionIdentifier{
+							Hash: "fake",
+						},
+						Operations: []*types.Operation{
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        0,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   InputOpType,
+								Status: types.String(SuccessStatus),
+								Amount: &types.Amount{
+									Value:    "-3467607",
+									Currency: MainnetCurrency,
+								},
+								Account: &types.AccountIdentifier{
+									Address: "3FfQGY7jqsADC7uTVqF3vKQzeNPiBPTqt4",
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinSpent,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptSig: &ScriptSig{
+										ASM: "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+										Hex: "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+									},
+									TxInWitness: []string{
+										"304402205f39ccbab38b644acea0776d18cb63ce3e37428cbac06dc23b59c61607aef69102206b8610827e9cb853ea0ba38983662034bd3575cc1ab118fb66d6a98066fa0bed01", // nolint
+										"0304c01563d46e38264283b99bb352b46e69bf132431f102d4bd9a9d8dab075e7f",
+									},
+									Sequence: 4294967295,
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        1,
+									NetworkIndex: int64Pointer(1),
+								},
+								Type:   InputOpType,
+								Status: types.String(SuccessStatus),
+								Amount: &types.Amount{
+									Value:    "0",
+									Currency: MainnetCurrency,
+								},
+								Account: &types.AccountIdentifier{
+									Address: "1NdvAyRJLdK5EXs7DV3ebYb5wffdCZk1pD",
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinSpent,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:1",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptSig: &ScriptSig{
+										ASM: "00142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+										Hex: "1600142b2296c588ec413cebd19c3cbc04ea830ead6e78",
+									},
+									Sequence: 4294967295,
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        2,
+									NetworkIndex: int64Pointer(2),
+								},
+								Type:   InputOpType,
+								Status: types.String(SuccessStatus),
+								Amount: &types.Amount{
+									Value:    "-556000000",
+									Currency: MainnetCurrency,
+								},
+								Account: &types.AccountIdentifier{
+									Address: "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinSpent,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptSig: &ScriptSig{
+										ASM: "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+										Hex: "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+									},
+									Sequence: 4294967295,
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        3,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   OutputOpType,
+								Status: types.String(SuccessStatus),
+								Account: &types.AccountIdentifier{
+									Address: "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+								},
+								Amount: &types.Amount{
+									Value:    "20056000000",
+									Currency: MainnetCurrency,
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinCreated,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "fake:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptPubKey: &ScriptPubKey{
+										ASM:          "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+										Hex:          "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+										RequiredSigs: 1,
+										Type:         "pubkeyhash",
+										Addresses: []string{
+											"1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+											"1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
+										},
+									},
+								}),
+							},
+						},
+						Metadata: mustMarshalMap(&TransactionMetadata{
+							Size:     421,
+							Version:  2,
+							Vsize:    612,
+							Weight:   129992,
+							Locktime: 10,
+						}),
+					},
+				},
+				Metadata: mustMarshalMap(&BlockMetadata{
+					Size:       957,
+					Weight:     3828,
+					Version:    1,
+					MerkleRoot: "f3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766",
+					MedianTime: 1293622620,
+					Nonce:      274148111,
+					Bits:       "1b04864c",
+					Difficulty: 14484.1623612254,
+				}),
+			},
+		},
+		"block 100000 (bis)": {
+			block: block100000_bis,
+			coins: map[string]*types.AccountCoin{
+				"87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03:0": {
+					Account: &types.AccountIdentifier{
+						Address: "1BNwxHGaFbeUBitpjy2AsKpJ29Ybxntqvb",
+					},
+					Coin: &types.Coin{
+						CoinIdentifier: &types.CoinIdentifier{
+							Identifier: "87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03:0",
+						},
+						Amount: &types.Amount{
+							Value:    "5000000000",
+							Currency: MainnetCurrency,
+						},
+					},
+				},
+				"503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:0": {
+					Account: &types.AccountIdentifier{
+						Address: "3FfQGY7jqsADC7uTVqF3vKQzeNPiBPTqt4",
+					},
+					Coin: &types.Coin{
+						CoinIdentifier: &types.CoinIdentifier{
+							Identifier: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:0",
+						},
+						Amount: &types.Amount{
+							Value:    "3467607",
+							Currency: MainnetCurrency,
+						},
+					},
+				},
+				"503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:1": {
+					Account: &types.AccountIdentifier{
+						Address: "1NdvAyRJLdK5EXs7DV3ebYb5wffdCZk1pD",
+					},
+					Coin: &types.Coin{
+						CoinIdentifier: &types.CoinIdentifier{
+							Identifier: "503e4e9824282eb06f1a328484e2b367b5f4f93a405d6e7b97261bafabfb53d5:1",
+						},
+						Amount: &types.Amount{
+							Value:    "0",
+							Currency: MainnetCurrency,
+						},
+					},
+				},
+			},
+			expectedBlock: &types.Block{
+				BlockIdentifier: blockIdentifier100000_bis,
+				ParentBlockIdentifier: &types.BlockIdentifier{
+					Hash:  "000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250",
+					Index: 99999,
+				},
+				Timestamp: 1293623863000,
+				Transactions: []*types.Transaction{
+					{
+						TransactionIdentifier: &types.TransactionIdentifier{
+							Hash: "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87",
+						},
+						Operations: []*types.Operation{
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        0,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   CoinbaseOpType,
+								Status: types.String(SuccessStatus),
+								Metadata: mustMarshalMap(&OperationMetadata{
+									Coinbase: "044c86041b020602",
+									Sequence: 4294967295,
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        1,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   OutputOpType,
+								Status: types.String(SuccessStatus),
+								Account: &types.AccountIdentifier{
+									Address: "34qkc2iac6RsyxZVfyE2S5U5WcRsbg2dpK",
+								},
+								Amount: &types.Amount{
+									Value:    "1589351625",
+									Currency: MainnetCurrency,
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinCreated,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptPubKey: &ScriptPubKey{
+										ASM:          "OP_HASH160 228f554bbf766d6f9cc828de1126e3d35d15e5fe OP_EQUAL",
+										Hex:          "a914228f554bbf766d6f9cc828de1126e3d35d15e5fe87",
+										RequiredSigs: 1,
+										Type:         "scripthash",
+										Address:      "34qkc2iac6RsyxZVfyE2S5U5WcRsbg2dpK",
+									},
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        2,
+									NetworkIndex: int64Pointer(1),
+								},
+								Type:   OutputOpType,
+								Status: types.String(SuccessStatus),
+								Account: &types.AccountIdentifier{
+									Address: "6a24aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+								},
+								Amount: &types.Amount{
+									Value:    "0",
+									Currency: MainnetCurrency,
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptPubKey: &ScriptPubKey{
+										ASM:  "OP_RETURN aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+										Hex:  "6a24aa21a9ed10109f4b82aa3ed7ec9d02a2a90246478b3308c8b85daf62fe501d58d05727a4",
+										Type: "nulldata",
+									},
+								}),
+							},
+						},
+						Metadata: mustMarshalMap(&TransactionMetadata{
+							Size:    135,
+							Version: 1,
+							Vsize:   135,
+							Weight:  540,
+						}),
+					},
+					{
+						TransactionIdentifier: &types.TransactionIdentifier{
+							Hash: "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
+						},
+						Operations: []*types.Operation{
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        0,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   InputOpType,
+								Status: types.String(SuccessStatus),
+								Amount: &types.Amount{
+									Value:    "-5000000000",
+									Currency: MainnetCurrency,
+								},
+								Account: &types.AccountIdentifier{
+									Address: "1BNwxHGaFbeUBitpjy2AsKpJ29Ybxntqvb",
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinSpent,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "87a157f3fd88ac7907c05fc55e271dc4acdc5605d187d646604ca8c0e9382e03:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptSig: &ScriptSig{
+										ASM: "3046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748[ALL] 04f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+										Hex: "493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3", // nolint
+									},
+									Sequence: 4294967295,
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        1,
+									NetworkIndex: int64Pointer(0),
+								},
+								Type:   OutputOpType,
+								Status: types.String(SuccessStatus),
+								Account: &types.AccountIdentifier{
+									Address: "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+								},
+								Amount: &types.Amount{
+									Value:    "556000000",
+									Currency: MainnetCurrency,
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinCreated,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4:0",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptPubKey: &ScriptPubKey{
+										ASM:          "OP_DUP OP_HASH160 c398efa9c392ba6013c5e04ee729755ef7f58b32 OP_EQUALVERIFY OP_CHECKSIG",
+										Hex:          "76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac",
+										RequiredSigs: 1,
+										Type:         "pubkeyhash",
+										Address:      "1JqDybm2nWTENrHvMyafbSXXtTk5Uv5QAn",
+									},
+								}),
+							},
+							{
+								OperationIdentifier: &types.OperationIdentifier{
+									Index:        2,
+									NetworkIndex: int64Pointer(1),
+								},
+								Type:   OutputOpType,
+								Status: types.String(SuccessStatus),
+								Account: &types.AccountIdentifier{
+									Address: "1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
+								},
+								Amount: &types.Amount{
+									Value:    "4444000000",
+									Currency: MainnetCurrency,
+								},
+								CoinChange: &types.CoinChange{
+									CoinAction: types.CoinCreated,
+									CoinIdentifier: &types.CoinIdentifier{
+										Identifier: "fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4:1",
+									},
+								},
+								Metadata: mustMarshalMap(&OperationMetadata{
+									ScriptPubKey: &ScriptPubKey{
+										ASM:          "OP_DUP OP_HASH160 948c765a6914d43f2a7ac177da2c2f6b52de3d7c OP_EQUALVERIFY OP_CHECKSIG",
+										Hex:          "76a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac",
+										RequiredSigs: 1,
+										Type:         "pubkeyhash",
+										Address:      "1EYTGtG4LnFfiMvjJdsU7GMGCQvsRSjYhx",
 									},
 								}),
 							},

--- a/bitcoin/types.go
+++ b/bitcoin/types.go
@@ -150,6 +150,7 @@ type ScriptPubKey struct {
 	RequiredSigs int64    `json:"reqSigs,omitempty"`
 	Type         string   `json:"type"`
 	Addresses    []string `json:"addresses,omitempty"`
+	Address      string   `json:"address,omitempty"`
 }
 
 // ScriptSig is a script on the input operations of a


### PR DESCRIPTION
Fixes # .

### Motivation
After Bitcoin core 23.0, `bitcoind` no longer returns the `addresses` field in RPC methods `gettxout`, `getrawtransaction`, `decoderawtransaction`, `decodescript`, `gettransaction verbose=true` (see [bitcoin release notes](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.0.md#updated-rpcs) for more detail).
Instead, a `address` field is returned, which should be decoded in a `Address string` field within the `ScriptPubKey` [struct](https://github.com/coinbase/rosetta-bitcoin/blob/master/bitcoin/types.go#L147) in bitcoin's client types.

### Solution
This PR contains a fix that supports both the deprecated `Addresses []string` field and the new `Address string` field, that will enable Rosetta-bitcoin implementation to be compatible with bitcoin core v23 while maintaining backward compatibility with previous bitcoin releases
Proposed code changes
- [`bitcoin/types.go`](https://github.com/coinbase/rosetta-bitcoin/blob/master/bitcoin/types.go#L147)
```go
type ScriptPubKey struct {
	ASM          string   `json:"asm"`
	Hex          string   `json:"hex"`
	RequiredSigs int64    `json:"reqSigs,omitempty"`
	Type         string   `json:"type"`
	Addresses    []string `json:"addresses,omitempty"`
        Address string  `json:"address,omitempty"` //! <---new field added 
}
```
- [`bitcoin/client.go`](https://github.com/coinbase/rosetta-bitcoin/blob/master/bitcoin/client.go#L773)
```go
func (b *Client) parseOutputAccount(
	scriptPubKey *ScriptPubKey,
) *types.AccountIdentifier {
	if scriptPubKey.Address == "" { // <--- new logic to handle both cases with "Addresses []string" and "Address string"
		if len(scriptPubKey.Addresses) != 1 {
			return &types.AccountIdentifier{Address: scriptPubKey.Hex}
		}
		return &types.AccountIdentifier{Address: scriptPubKey.Addresses[0]}
	}
	return &types.AccountIdentifier{Address: scriptPubKey.Address}
}
```

Unit tests for the bitcoin client have been slightly modified to take the new scenario into consideration.
- A new client fixture json file has been added (`get_block_responses_2_bis.json`) which is a copy of the original test data (i.e. `get_block_responses_2.json`) but with the data fields modified as described above.
- In line with the new json file added, a `var` with the corresponding new block (`block100000_bis`) has been added to the test file `bitcoin/client_test.go` to update unit tests accordigly

### Open questions
N/A
